### PR TITLE
Pull's need to return a list of changed files.

### DIFF
--- a/unicore/distribute/api/repos.py
+++ b/unicore/distribute/api/repos.py
@@ -1,5 +1,4 @@
 import os
-import json
 from urlparse import urlparse
 
 from cornice.resource import resource, view

--- a/unicore/distribute/api/tests/test_repos.py
+++ b/unicore/distribute/api/tests/test_repos.py
@@ -29,16 +29,19 @@ class TestRepositoryResource(ModelBaseTest):
 
     def setUp(self):
         self.workspace = self.mk_workspace()
-        self.schema_string = serialize(TestPerson)
-        self.schema = json.loads(self.schema_string)
-        self.workspace.sm.store_data(
-            os.path.join(
-                '_schemas',
-                '%(namespace)s.%(name)s.avsc' % self.schema),
-            self.schema_string, 'Writing the schema.')
+        self.add_schema(self.workspace, TestPerson)
         self.config = testing.setUp(settings={
             'repo.storage_path': self.WORKING_DIR,
         })
+
+    def add_schema(self, workspace, model_class):
+        schema_string = serialize(model_class)
+        schema = json.loads(schema_string)
+        workspace.sm.store_data(
+            os.path.join(
+                '_schemas',
+                '%(namespace)s.%(name)s.avsc' % schema),
+            schema_string, 'Writing the schema.')
 
     def create_upstream_for(self, workspace, create_remote=True,
                             remote_name='origin',
@@ -150,11 +153,7 @@ class TestRepositoryResource(ModelBaseTest):
 
     def test_pull_additions(self):
         upstream_workspace = self.create_upstream_for(self.workspace)
-        upstream_workspace.sm.store_data(
-            os.path.join(
-                '_schemas',
-                '%(namespace)s.%(name)s.avsc' % self.schema),
-            self.schema_string, 'Writing the schema.')
+        self.add_schema(upstream_workspace, TestPerson)
         person1 = TestPerson({'age': 1, 'name': 'person1'})
         upstream_workspace.save(person1, 'Adding person1.')
 
@@ -174,11 +173,7 @@ class TestRepositoryResource(ModelBaseTest):
 
     def test_pull_removals(self):
         upstream_workspace = self.create_upstream_for(self.workspace)
-        upstream_workspace.sm.store_data(
-            os.path.join(
-                '_schemas',
-                '%(namespace)s.%(name)s.avsc' % self.schema),
-            self.schema_string, 'Writing the schema.')
+        self.add_schema(upstream_workspace, TestPerson)
         person1 = TestPerson({'age': 1, 'name': 'person1'})
         upstream_workspace.save(person1, 'Adding person1.')
         self.workspace.pull()
@@ -200,11 +195,7 @@ class TestRepositoryResource(ModelBaseTest):
 
     def test_pull_renames(self):
         upstream_workspace = self.create_upstream_for(self.workspace)
-        upstream_workspace.sm.store_data(
-            os.path.join(
-                '_schemas',
-                '%(namespace)s.%(name)s.avsc' % self.schema),
-            self.schema_string, 'Writing the schema.')
+        self.add_schema(upstream_workspace, TestPerson)
         upstream_workspace.sm.store_data(
             'README.rst', 'the readme', 'Writing the readme.')
         self.workspace.pull()
@@ -227,13 +218,9 @@ class TestRepositoryResource(ModelBaseTest):
             'rename_to': 'README.txt',
         })
 
-    def test_pull_renames(self):
+    def test_pull_modified(self):
         upstream_workspace = self.create_upstream_for(self.workspace)
-        upstream_workspace.sm.store_data(
-            os.path.join(
-                '_schemas',
-                '%(namespace)s.%(name)s.avsc' % self.schema),
-            self.schema_string, 'Writing the schema.')
+        self.add_schema(upstream_workspace, TestPerson)
         person1 = TestPerson({'age': 1, 'name': 'person1'})
         upstream_workspace.save(person1, 'Adding person1.')
         self.workspace.pull()

--- a/unicore/distribute/api/tests/test_repos.py
+++ b/unicore/distribute/api/tests/test_repos.py
@@ -29,16 +29,28 @@ class TestRepositoryResource(ModelBaseTest):
 
     def setUp(self):
         self.workspace = self.mk_workspace()
-        schema_string = serialize(TestPerson)
-        schema = json.loads(schema_string)
+        self.schema_string = serialize(TestPerson)
+        self.schema = json.loads(self.schema_string)
         self.workspace.sm.store_data(
             os.path.join(
                 '_schemas',
-                '%(namespace)s.%(name)s.avsc' % schema),
-            schema_string, 'Writing the schema.')
+                '%(namespace)s.%(name)s.avsc' % self.schema),
+            self.schema_string, 'Writing the schema.')
         self.config = testing.setUp(settings={
             'repo.storage_path': self.WORKING_DIR,
         })
+
+    def create_upstream_for(self, workspace, create_remote=True,
+                            remote_name='origin',
+                            suffix='upstream'):
+        upstream_workspace = self.mk_workspace(
+            name='%s_%s' % (self.id().lower(), suffix),
+            index_prefix='%s_%s' % (self.workspace.index_prefix,
+                                    suffix))
+        if create_remote:
+            workspace.repo.create_remote(
+                remote_name, upstream_workspace.working_dir)
+        return upstream_workspace
 
     def test_collection_get(self):
         request = testing.DummyRequest({})
@@ -135,6 +147,112 @@ class TestRepositoryResource(ModelBaseTest):
                 'repo': repo_name,
                 'url': 'foo',
             })
+
+    def test_pull_additions(self):
+        upstream_workspace = self.create_upstream_for(self.workspace)
+        upstream_workspace.sm.store_data(
+            os.path.join(
+                '_schemas',
+                '%(namespace)s.%(name)s.avsc' % self.schema),
+            self.schema_string, 'Writing the schema.')
+        person1 = TestPerson({'age': 1, 'name': 'person1'})
+        upstream_workspace.save(person1, 'Adding person1.')
+
+        repo_name = os.path.basename(self.workspace.working_dir)
+        request = testing.DummyRequest({})
+        request.route_url = lambda route, name: 'foo'
+        request.matchdict = {
+            'name': repo_name,
+        }
+
+        resource = RepositoryResource(request)
+        [diff] = resource.post()
+        self.assertEqual(diff, {
+            'type': 'A',
+            'path': upstream_workspace.sm.git_name(person1),
+        })
+
+    def test_pull_removals(self):
+        upstream_workspace = self.create_upstream_for(self.workspace)
+        upstream_workspace.sm.store_data(
+            os.path.join(
+                '_schemas',
+                '%(namespace)s.%(name)s.avsc' % self.schema),
+            self.schema_string, 'Writing the schema.')
+        person1 = TestPerson({'age': 1, 'name': 'person1'})
+        upstream_workspace.save(person1, 'Adding person1.')
+        self.workspace.pull()
+        upstream_workspace.delete(person1, 'Removing person1.')
+
+        repo_name = os.path.basename(self.workspace.working_dir)
+        request = testing.DummyRequest({})
+        request.route_url = lambda route, name: 'foo'
+        request.matchdict = {
+            'name': repo_name,
+        }
+
+        resource = RepositoryResource(request)
+        [diff] = resource.post()
+        self.assertEqual(diff, {
+            'type': 'D',
+            'path': upstream_workspace.sm.git_name(person1),
+        })
+
+    def test_pull_renames(self):
+        upstream_workspace = self.create_upstream_for(self.workspace)
+        upstream_workspace.sm.store_data(
+            os.path.join(
+                '_schemas',
+                '%(namespace)s.%(name)s.avsc' % self.schema),
+            self.schema_string, 'Writing the schema.')
+        upstream_workspace.sm.store_data(
+            'README.rst', 'the readme', 'Writing the readme.')
+        self.workspace.pull()
+        # do the rename
+        upstream_workspace.repo.index.move(['README.rst', 'README.txt'])
+        upstream_workspace.repo.index.commit('Renaming rst to txt.')
+
+        repo_name = os.path.basename(self.workspace.working_dir)
+        request = testing.DummyRequest({})
+        request.route_url = lambda route, name: 'foo'
+        request.matchdict = {
+            'name': repo_name,
+        }
+
+        resource = RepositoryResource(request)
+        [diff] = resource.post()
+        self.assertEqual(diff, {
+            'type': 'R',
+            'rename_from': 'README.rst',
+            'rename_to': 'README.txt',
+        })
+
+    def test_pull_renames(self):
+        upstream_workspace = self.create_upstream_for(self.workspace)
+        upstream_workspace.sm.store_data(
+            os.path.join(
+                '_schemas',
+                '%(namespace)s.%(name)s.avsc' % self.schema),
+            self.schema_string, 'Writing the schema.')
+        person1 = TestPerson({'age': 1, 'name': 'person1'})
+        upstream_workspace.save(person1, 'Adding person1.')
+        self.workspace.pull()
+        updated_person1 = person1.update({'age': 2})
+        upstream_workspace.save(updated_person1, 'Updating person1.')
+
+        repo_name = os.path.basename(self.workspace.working_dir)
+        request = testing.DummyRequest({})
+        request.route_url = lambda route, name: 'foo'
+        request.matchdict = {
+            'name': repo_name,
+        }
+
+        resource = RepositoryResource(request)
+        [diff] = resource.post()
+        self.assertEqual(diff, {
+            'type': 'M',
+            'path': upstream_workspace.sm.git_name(person1),
+        })
 
 
 class TestContentTypeResource(ModelBaseTest):

--- a/unicore/distribute/utils.py
+++ b/unicore/distribute/utils.py
@@ -9,6 +9,7 @@ from ConfigParser import ConfigParser
 from pyramid.exceptions import NotFound
 
 from git import Repo
+from git.diff import Diff
 from git.exc import InvalidGitRepositoryError, NoSuchPathError, GitCommandError
 
 import avro.schema
@@ -157,6 +158,47 @@ def format_repo(repo):
         'author': '%s <%s>' % (commit.author.name, commit.author.email),
         'schemas': list_schemas(repo)
     }
+
+
+def format_diff_A(diff):
+    return {
+        'type': 'A',
+        'path': diff.b_blob.path,
+    }
+
+
+def format_diff_D(diff):
+    return {
+        'type': 'D',
+        'path': diff.a_blob.path,
+    }
+
+
+def format_diff_R(diff):
+    return {
+        'type': 'R',
+        'rename_from': diff.rename_from,
+        'rename_to': diff.rename_to,
+    }
+
+
+def format_diff_M(diff):
+    return {
+        'type': 'M',
+        'path': diff.a_blob.path,
+    }
+
+
+def format_diffindex(diff_index):
+    for diff in diff_index:
+        if diff.new_file:
+            yield format_diff_A(diff)
+        elif diff.deleted_file:
+            yield format_diff_D(diff)
+        elif diff.renamed:
+            yield format_diff_R(diff)
+        elif diff.a_blob and diff.b_blob and diff.a_blob != diff.b_blob:
+            yield format_diff_M(diff)
 
 
 def format_content_type(repo, content_type):

--- a/unicore/distribute/utils.py
+++ b/unicore/distribute/utils.py
@@ -190,6 +190,35 @@ def format_diff_M(diff):
 
 
 def format_diffindex(diff_index):
+    """
+    Return a JSON formattable representation of a DiffIndex.
+
+    Returns a generator that returns dictionaries representing the changes.
+
+    .. code::
+        [
+            {
+                'type': 'A',
+                'path': 'path/to/added/file.txt',
+            },
+            {
+                'type': 'D',
+                'path': 'path/to/deleted/file.txt',
+            },
+            {
+                'type': 'M',
+                'path': 'path/to/modified/file.txt',
+            },
+            {
+                'type': 'R',
+                'rename_from': 'original/path/to/file.txt',
+                'rename_to': 'new/path/to/file.txt',
+            },
+        ]
+
+    :returns: generator
+
+    """
     for diff in diff_index:
         if diff.new_file:
             yield format_diff_A(diff)

--- a/unicore/distribute/utils.py
+++ b/unicore/distribute/utils.py
@@ -9,7 +9,6 @@ from ConfigParser import ConfigParser
 from pyramid.exceptions import NotFound
 
 from git import Repo
-from git.diff import Diff
 from git.exc import InvalidGitRepositoryError, NoSuchPathError, GitCommandError
 
 import avro.schema


### PR DESCRIPTION
External services may need to update their indexes as a result of changes being applied due to a merge.
