### PR TITLE
Bug - pip install does not install slugify dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest
 pytest-cov
 pytest-xdist
-python-slugify
 Sphinx
 sphinx_rtd_theme
 webtest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyramid-celery>=2.0.0rc4
 cornice==1.0.0
 colander==1.0
 requests
+python-slugify


### PR DESCRIPTION
Pip installs all dependencies except for slugify. Was using virtualenv but doubt that is the cause issue.
