### PR TITLE
allow a name to be specified for a repo

### DIFF
--- a/unicore/distribute/api/repos.py
+++ b/unicore/distribute/api/repos.py
@@ -39,9 +39,12 @@ class RepositoryResource(object):
     def collection_post(self):
         storage_path = self.config.get('repo.storage_path')
         repo_url = self.request.validated['repo_url']
-        repo_url_info = urlparse(repo_url)
-        repo_name_dot_git = os.path.basename(repo_url_info.path)
-        repo_name = repo_name_dot_git.partition('.git')[0]
+        repo_name = self.request.validated['repo_name']
+        if not repo_name:
+            repo_url_info = urlparse(repo_url)
+            repo_name_dot_git = os.path.basename(repo_url_info.path)
+            repo_name = repo_name_dot_git.partition('.git')[0]
+
         try:
             repo = EG.clone_repo(
                 repo_url, os.path.join(storage_path, repo_name))

--- a/unicore/distribute/api/tests/test_validators.py
+++ b/unicore/distribute/api/tests/test_validators.py
@@ -10,7 +10,8 @@ from colander import Invalid
 from cornice.errors import Errors
 
 from unicore.distribute.api.validators import (
-    validate_schema, repo_url_type_schema_validator, CreateRepoColanderSchema)
+    validate_schema, repo_url_type_schema_validator, CreateRepoColanderSchema,
+    repo_name_validator)
 
 from pyramid import testing
 
@@ -93,8 +94,15 @@ class TestValidators(ModelBaseTest):
         self.assertEqual(
             None, repo_url_type_schema_validator(None, 'git://foo/bar.git'))
 
+    def test_repo_name_validator(self):
+        self.assertRaises(Invalid, repo_name_validator, None, '/foo/bar.git')
+        self.assertRaises(Invalid, repo_name_validator, None, '.')
+        self.assertRaises(Invalid, repo_name_validator, None, '..')
+        self.assertEqual(None, repo_name_validator(None, 'abcd1234.-_'))
+
     def test_create_repo_colander_schema(self):
         schema = CreateRepoColanderSchema()
         valid = schema.deserialize({'repo_url': 'http://example.org/foo.git'})
-        self.assertEqual(valid, {'repo_url': 'http://example.org/foo.git'})
+        self.assertEqual(valid, {'repo_url': 'http://example.org/foo.git',
+                                 'repo_name': None})
         self.assertRaises(Invalid, schema.deserialize, {'repo_url': 'foo'})

--- a/unicore/distribute/api/validators.py
+++ b/unicore/distribute/api/validators.py
@@ -8,6 +8,9 @@ from colander import MappingSchema, SchemaNode, String, Invalid
 from unicore.distribute.utils import get_config, get_repository, get_schema
 
 
+REPO_NAME_CHARS = set('abcdefghijklmnopqrstuvwxyz0123456789.-_')
+
+
 def validate_schema(request):
     config = get_config(request)
     storage_path = config.get('repo.storage_path')
@@ -43,6 +46,17 @@ def repo_url_type_schema_validator(node, value):
         raise Invalid(node, '%r is not a valid repo_url' % (value,))
 
 
+def repo_name_validator(node, value):
+    chars = set(value)
+    if not chars <= REPO_NAME_CHARS:
+        raise Invalid(node, '%r contains invalid characters %r' % (
+            value, chars - REPO_NAME_CHARS))
+    if value in ('.', '..'):
+        raise Invalid(node, '%r is not a valid repo_name' % (value,))
+
+
 class CreateRepoColanderSchema(MappingSchema):
     repo_url = SchemaNode(
         String(), location='body', validator=repo_url_type_schema_validator)
+    repo_name = SchemaNode(
+        String(), location='body', validator=repo_name_validator, missing=None)


### PR DESCRIPTION
The repo name is currently the base name of the repo URL. This can stay the default.
