### PR TITLE
error when proxy.upstream has no trailing slash

### DIFF
--- a/unicore/distribute/api/__init__.py
+++ b/unicore/distribute/api/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from pyramid.config import Configurator
 
 from unicore.distribute.api import proxy
@@ -20,7 +22,7 @@ def includeme(config):
     proxy_upstream = settings.get('proxy.upstream', 'http://localhost:9200/')
 
     if proxy_enabled == 'true':  # pragma: no cover
-        config.add_route('esapi', '/%s/{parts:.*}' % (proxy_path,))
+        config.add_route('esapi', os.path.join('/', proxy_path, '{parts:.*}'))
         config.add_view(proxy.Proxy(proxy_upstream), route_name='esapi')
 
     indexing_enabled = settings.get('es.indexing_enabled', 'false').lower()

--- a/unicore/distribute/api/proxy.py
+++ b/unicore/distribute/api/proxy.py
@@ -1,3 +1,5 @@
+from urlparse import urljoin
+
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPNotFound
 
@@ -22,7 +24,7 @@ class ProxyView(object):
         self.upstream_url = upstream_url
 
     def url(self):
-        return '%s%s' % (self.upstream_url, self.request.matchdict['parts'])
+        return urljoin(self.upstream_url, self.request.matchdict['parts'])
 
     def mk_request(self, *args, **kwargs):  # for mocking
         return requests.request(*args, **kwargs)


### PR DESCRIPTION
Check here https://github.com/universalcore/unicore.distribute/blob/develop/unicore/distribute/api/proxy.py#L25
