### PR TITLE
optimise get all repos api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install -e .
 script:
   - flake8 unicore
-  - py.test --cov unicore unicore
+  - py.test
 after_success:
   - coveralls
 deploy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pytest]
-addopts = --verbose
+addopts = --verbose --cov unicore unicore
 looponfailroots = ./unicore/
 
 [flake8]
-exclude = **/alembic/versions/*.py
+exclude = **/alembic/versions/*.py,ve,docs

--- a/unicore/distribute/api/repos.py
+++ b/unicore/distribute/api/repos.py
@@ -21,7 +21,8 @@ from unicore.distribute.utils import (
     format_content_type, format_content_type_object,
     save_content_type_object, delete_content_type_object,
     format_diffindex, get_index_prefix, load_model_class,
-    get_es, get_es_settings, get_mapping, list_content_types)
+    get_es, get_es_settings, get_mapping, list_content_types,
+    get_repository_names)
 
 
 @resource(collection_path='/repos.json', path='/repos/{name}.json')
@@ -33,6 +34,10 @@ class RepositoryResource(object):
 
     def collection_get(self):
         storage_path = self.config.get('repo.storage_path')
+        if self.request.GET.get('name_only'):
+            return [
+                {'name': repo_path}
+                for repo_path in get_repository_names(storage_path)]
         return [format_repo(repo) for repo in get_repositories(storage_path)]
 
     @view(schema=CreateRepoColanderSchema)

--- a/unicore/distribute/api/tests/test_repos.py
+++ b/unicore/distribute/api/tests/test_repos.py
@@ -60,6 +60,14 @@ class TestRepositoryResource(DistributeTestCase):
         [repo_json] = resource.collection_get()
         self.assertEqual(repo_json, format_repo(self.workspace.repo))
 
+    def test_collection_get_name_only(self):
+        request = testing.DummyRequest({'name_only': True})
+        resource = RepositoryResource(request)
+        [repo_json] = resource.collection_get()
+        self.assertEqual(repo_json, {
+            'name': 'unicore.distribute.api.tests.test_repos.'
+                    'TestRepositoryResource.test_collection_get_name_only'})
+
     def test_collection_post_success(self):
         # NOTE: cloning to a different directory called `remote` because
         #       the API is trying to clone into the same folder as the
@@ -119,7 +127,7 @@ class TestRepositoryResource(DistributeTestCase):
 
         with patch.object(
                 ESManager, 'destroy_index', wraps=im.destroy_index
-                ) as mocked_destroy:
+        ) as mocked_destroy:
             initialize_repo_index(event)
             self.assertTrue(mocked_destroy.called)
             self.assertTrue(im.index_exists(sm.active_branch()))

--- a/unicore/distribute/utils.py
+++ b/unicore/distribute/utils.py
@@ -86,12 +86,12 @@ def get_repositories(path):
 
 def get_repository_names(path):
     """
-    Return an array of tuples with the name and path for
+    Return an array of the path name for
     repositories found in a directory.
 
     :param str path:
         The path to find repositories in
-    :returns: tuple
+    :returns: array
     """
     return [subdir
             for subdir in os.listdir(path)

--- a/unicore/distribute/utils.py
+++ b/unicore/distribute/utils.py
@@ -84,6 +84,20 @@ def get_repositories(path):
             os.path.join(path, subdir, '.git'))]
 
 
+def get_repository_names(path):
+    """
+    Return an array of tuples with the name and path for
+    repositories found in a directory.
+
+    :param str path:
+        The path to find repositories in
+    :returns: tuple
+    """
+    return [subdir
+            for subdir in os.listdir(path)
+            if os.path.isdir(os.path.join(path, subdir, '.git'))]
+
+
 def get_repository(path):
     """
     Return a repository for whatever's at a path


### PR DESCRIPTION
Allows you to specify `/repost.json?name_only=true` which doesn't try to load the repo using GitPython
